### PR TITLE
Fixed outside screen detection

### DIFF
--- a/OpenGLApp/OpenGLApp/asteroids/object.cpp
+++ b/OpenGLApp/OpenGLApp/asteroids/object.cpp
@@ -38,12 +38,12 @@ bool Object::isOutOfScreen() {
 	tmpVector.x = pos.x + radius;
 	tmpVector.y = pos.y + radius;
 	tmpVector = scaleVector(tmpVector);
-	if(tmpVector.x > 1 || tmpVector.y > 1) return true;
+	if(tmpVector.x < -1 || tmpVector.y < -1) return true;
 
 	tmpVector.x = pos.x - radius;
 	tmpVector.y = pos.y - radius;
 	tmpVector = scaleVector(tmpVector);
-	if(tmpVector.x < -1 || tmpVector.y < -1) return true;
+	if(tmpVector.x > 1 || tmpVector.y > 1) return true;
 
 	return false;
 }


### PR DESCRIPTION
Along the non-scaled dimension, objects were considered "out of screen" as soon as they touched the border. This is no longer the case, they must be fully outside the window to be considered "out of screen"